### PR TITLE
Adding arm64 support

### DIFF
--- a/.github/workflows/workflow-docker-manual.yml
+++ b/.github/workflows/workflow-docker-manual.yml
@@ -12,6 +12,7 @@ jobs:
     uses: binhex/workflow-templates/.github/workflows/workflow-docker-manual.yml@main
     with:
       tags: ${{ github.event.inputs.tags }}
+      platforms: linux/amd64,linux/arm64
     secrets:
       CR_PAT: ${{ secrets.CR_PAT }}
       DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}

--- a/.github/workflows/workflow-docker-release.yml
+++ b/.github/workflows/workflow-docker-release.yml
@@ -10,6 +10,7 @@ jobs:
     uses: binhex/workflow-templates/.github/workflows/workflow-docker-release.yml@main
     with:
       tags: ${{ github.event.inputs.tags }}
+      platforms: linux/amd64,linux/arm64
     secrets:
       CR_PAT: ${{ secrets.CR_PAT }}
       DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}


### PR DESCRIPTION
I found that this container was missing arm64 support, so I've updated the GitHub action workflow to include this platform when building newer versions.